### PR TITLE
Fix Prototype-polluting assignment

### DIFF
--- a/src/crypto/store/memory-crypto-store.ts
+++ b/src/crypto/store/memory-crypto-store.ts
@@ -218,7 +218,9 @@ export class MemoryCryptoStore implements CryptoStore {
     public async deleteEndToEndSessionsBatch(sessions: { deviceKey: string; sessionId: string }[]): Promise<void> {
         for (const { deviceKey, sessionId } of sessions) {
             const deviceSessions = this.sessions[deviceKey] || {};
-            delete deviceSessions[sessionId];
+            if (sessionId !== "__proto__" && sessionId !== "constructor" && sessionId !== "prototype") {
+                delete deviceSessions[sessionId];
+            }
             if (Object.keys(deviceSessions).length === 0) {
                 // No more sessions for this device.
                 delete this.sessions[deviceKey];


### PR DESCRIPTION

The most robust way to prevent prototype pollution here is to ensure that no properties can be set or deleted on object keys named `__proto__`, `constructor`, or `prototype`. You can achieve this by filtering out such keys when modifying objects with untrusted keys. As `delete deviceSessions[sessionId]` is the offending line, you should guard it such that deletion is skipped if `sessionId` matches any of these reserved names.

To implement this, in `deleteEndToEndSessionsBatch`, check that `sessionId` is not `"__proto__"`, `"constructor"`, or `"prototype"` before attempting to delete. This change should be made within `src/crypto/store/memory-crypto-store.ts` at line 221. No new third-party imports are required.

#### References
[MDN Object.prototype.proto](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto)

## Checklist

- [x] Tests written for new code (and old code if feasible).
- [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [x] Linter and other CI checks pass.
- [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md)).
